### PR TITLE
[feat/#8] 주문 요약 컴포넌트 수량 증감 버튼 추가

### DIFF
--- a/meal-ticket-system-main/src/components/OrderSummary.jsx
+++ b/meal-ticket-system-main/src/components/OrderSummary.jsx
@@ -6,11 +6,26 @@ import React from 'react';
  * @param {Array} props.order - 주문 목록
  * @param {Function} props.onCancelOrder - 전체 취소 핸들러
  * @param {Function} props.onCheckout - 결제하기 핸들러
+ * @param {Function} props.onQuantityChange - 수량 변경 핸들러
  */
-function OrderSummary({ order, onCancelOrder, onCheckout }) {
+function OrderSummary({ order, onCancelOrder, onCheckout, onQuantityChange }) {
   // 주문 요약 계산
   const totalAmount = order.reduce((sum, item) => sum + (item.price * item.quantity), 0);
   const totalQuantity = order.reduce((sum, item) => sum + item.quantity, 0);
+
+  // 수량 증가 핸들러
+  const handleIncreaseQuantity = (itemId) => {
+    if (onQuantityChange) {
+      onQuantityChange(itemId, 1);
+    }
+  };
+
+  // 수량 감소 핸들러
+  const handleDecreaseQuantity = (itemId) => {
+    if (onQuantityChange) {
+      onQuantityChange(itemId, -1);
+    }
+  };
 
   return (
     <>
@@ -31,7 +46,23 @@ function OrderSummary({ order, onCancelOrder, onCheckout }) {
             order.map(item => (
               <div key={item.id} className="summary-item">
                 <span className="item-name">{item.name}</span>
-                <span className="item-quantity">x{item.quantity}</span>
+                <div className="item-quantity-controls">
+                  <button 
+                    className="quantity-btn decrease-btn" 
+                    onClick={() => handleDecreaseQuantity(item.id)}
+                    aria-label="수량 감소"
+                  >
+                    -
+                  </button>
+                  <span className="item-quantity">{item.quantity}</span>
+                  <button 
+                    className="quantity-btn increase-btn" 
+                    onClick={() => handleIncreaseQuantity(item.id)}
+                    aria-label="수량 증가"
+                  >
+                    +
+                  </button>
+                </div>
                 <span className="item-price">{(item.price * item.quantity).toLocaleString()}원</span>
               </div>
             ))

--- a/meal-ticket-system-main/src/pages/KioskMenuPage.jsx
+++ b/meal-ticket-system-main/src/pages/KioskMenuPage.jsx
@@ -107,6 +107,25 @@ function KioskMenuPage() {
     setSelectedMenu(null);
   };
 
+  const handleQuantityChange = (itemId, change) => {
+    setOrder(prevOrder => {
+      const existingItem = prevOrder.find(item => item.id === itemId);
+      if (existingItem) {
+        const newQuantity = existingItem.quantity + change;
+        if (newQuantity <= 0) {
+          // 수량이 0 이하면 주문에서 제거
+          return prevOrder.filter(item => item.id !== itemId);
+        } else {
+          // 수량 업데이트
+          return prevOrder.map(item =>
+            item.id === itemId ? { ...item, quantity: newQuantity } : item
+          );
+        }
+      }
+      return prevOrder;
+    });
+  };
+
   return (
     <>
       <Navbar />
@@ -131,6 +150,7 @@ function KioskMenuPage() {
           order={order}
           onCancelOrder={handleCancelOrder}
           onCheckout={handleCheckout}
+          onQuantityChange={handleQuantityChange}
         />
         
         <div className="kiosk-instruction">

--- a/meal-ticket-system-main/src/styles/kioskMenuPage.css
+++ b/meal-ticket-system-main/src/styles/kioskMenuPage.css
@@ -91,6 +91,7 @@
   box-shadow: 0 4px 15px rgba(0, 123, 255, 0.3);
 }
 
+
 /* 메뉴 콘텐츠 */
 .kiosk-menu-content {
   padding: 20px;
@@ -235,10 +236,55 @@
   flex: 1;
 }
 
-.item-quantity {
-  color: #6c757d;
+.item-quantity-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 0 15px;
-  font-weight: 500;
+}
+
+.quantity-btn {
+  background: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 50%;
+  width: 28px;
+  height: 28px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.3s ease;
+  box-shadow: 0 2px 4px rgba(0, 123, 255, 0.2);
+}
+
+.quantity-btn:hover {
+  background: #0056b3;
+  transform: scale(1.1);
+  box-shadow: 0 4px 8px rgba(0, 123, 255, 0.3);
+}
+
+.quantity-btn:active {
+  transform: scale(0.95);
+}
+
+.decrease-btn {
+  background: #dc3545;
+}
+
+.decrease-btn:hover {
+  background: #c82333;
+  box-shadow: 0 4px 8px rgba(220, 53, 69, 0.3);
+}
+
+.item-quantity {
+  color: #495057;
+  font-weight: 600;
+  font-size: 1rem;
+  min-width: 20px;
+  text-align: center;
 }
 
 .item-price {
@@ -355,6 +401,7 @@
     border-radius: 15px;
   }
   
+
   .kiosk-menu-content {
     padding: 15px;
   }
@@ -462,6 +509,7 @@
     font-size: 0.8rem;
   }
   
+
   .kiosk-menu-content {
     padding: 10px;
   }
@@ -509,6 +557,21 @@
   .kiosk-cancel-btn, .kiosk-checkout-btn {
     padding: 8px;
     font-size: 0.8rem;
+  }
+
+  .item-quantity-controls {
+    gap: 6px;
+    margin: 0 10px;
+  }
+
+  .quantity-btn {
+    width: 24px;
+    height: 24px;
+    font-size: 0.9rem;
+  }
+
+  .item-quantity {
+    font-size: 0.9rem;
   }
 }
 


### PR DESCRIPTION
Resolve #8 
## 변경 사항
- 선택된 메뉴에 대한 증감 버튼 추가
- +를 누를 시 개수 1 증가
- -를 누를 시 개수 1 감소(0이 되는 경우 삭제)

## 테스트 방법
- 키오스크 페이지에서 메뉴 선택 후 + 혹은 - 버튼 클릭

## 스크린샷 (UI 관련시)
<img width="1960" height="461" alt="image" src="https://github.com/user-attachments/assets/ec3c2fec-69d0-4b76-b53f-5aa3254d64e9" />

## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트