### PR TITLE
[feat/#16] 장바구니가 비었을 때 결제 버튼 비활성화

### DIFF
--- a/meal-ticket-system-main/src/components/OrderSummary.jsx
+++ b/meal-ticket-system-main/src/components/OrderSummary.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React from "react";
 
 /**
  * 주문 요약 컴포넌트
@@ -10,7 +10,10 @@ import React from 'react';
  */
 function OrderSummary({ order, onCancelOrder, onCheckout, onQuantityChange }) {
   // 주문 요약 계산
-  const totalAmount = order.reduce((sum, item) => sum + (item.price * item.quantity), 0);
+  const totalAmount = order.reduce(
+    (sum, item) => sum + item.price * item.quantity,
+    0
+  );
   const totalQuantity = order.reduce((sum, item) => sum + item.quantity, 0);
 
   // 수량 증가 핸들러
@@ -30,40 +33,44 @@ function OrderSummary({ order, onCancelOrder, onCheckout, onQuantityChange }) {
   return (
     <>
       {/* 주문 요약 */}
-      <div className="kiosk-order-summary">
-        <div className="order-summary-header">
-          <h2 className="summary-title">주문메뉴</h2>
-          <div className="summary-stats">
-            <span className="summary-quantity">수량 {totalQuantity}개</span>
-            <span className="summary-amount">금액 {totalAmount.toLocaleString()}원</span>
+      <div className='kiosk-order-summary'>
+        <div className='order-summary-header'>
+          <h2 className='summary-title'>주문메뉴</h2>
+          <div className='summary-stats'>
+            <span className='summary-quantity'>수량 {totalQuantity}개</span>
+            <span className='summary-amount'>
+              금액 {totalAmount.toLocaleString()}원
+            </span>
           </div>
         </div>
-        
-        <div className="summary-list">
+
+        <div className='summary-list'>
           {order.length === 0 ? (
-            <div className="empty-order">메뉴를 선택해주세요</div>
+            <div className='empty-order'>메뉴를 선택해주세요</div>
           ) : (
-            order.map(item => (
-              <div key={item.id} className="summary-item">
-                <span className="item-name">{item.name}</span>
-                <div className="item-quantity-controls">
-                  <button 
-                    className="quantity-btn decrease-btn" 
+            order.map((item) => (
+              <div key={item.id} className='summary-item'>
+                <span className='item-name'>{item.name}</span>
+                <div className='item-quantity-controls'>
+                  <button
+                    className='quantity-btn decrease-btn'
                     onClick={() => handleDecreaseQuantity(item.id)}
-                    aria-label="수량 감소"
+                    aria-label='수량 감소'
                   >
                     -
                   </button>
-                  <span className="item-quantity">{item.quantity}</span>
-                  <button 
-                    className="quantity-btn increase-btn" 
+                  <span className='item-quantity'>{item.quantity}</span>
+                  <button
+                    className='quantity-btn increase-btn'
                     onClick={() => handleIncreaseQuantity(item.id)}
-                    aria-label="수량 증가"
+                    aria-label='수량 증가'
                   >
                     +
                   </button>
                 </div>
-                <span className="item-price">{(item.price * item.quantity).toLocaleString()}원</span>
+                <span className='item-price'>
+                  {(item.price * item.quantity).toLocaleString()}원
+                </span>
               </div>
             ))
           )}
@@ -71,11 +78,15 @@ function OrderSummary({ order, onCancelOrder, onCheckout, onQuantityChange }) {
       </div>
 
       {/* 액션 바 */}
-      <div className="kiosk-action-bar">
-        <button className="kiosk-cancel-btn" onClick={onCancelOrder}>
+      <div className='kiosk-action-bar'>
+        <button className='kiosk-cancel-btn' onClick={onCancelOrder}>
           전체취소
         </button>
-        <button className="kiosk-checkout-btn" onClick={onCheckout}>
+        <button
+          className='kiosk-checkout-btn'
+          onClick={onCheckout}
+          disabled={order.length === 0}
+        >
           결제하기
         </button>
       </div>

--- a/meal-ticket-system-main/src/styles/kioskMenuPage.css
+++ b/meal-ticket-system-main/src/styles/kioskMenuPage.css
@@ -4,10 +4,10 @@
   margin: 40px auto 0 auto;
   background: #fff;
   border-radius: 20px;
-  box-shadow: 0 4px 20px rgba(0,0,0,0.08);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.08);
   padding: 30px 20px;
   min-height: 500px;
-  font-family: 'Arial', sans-serif;
+  font-family: "Arial", sans-serif;
 }
 
 /* 헤더 */
@@ -91,7 +91,6 @@
   box-shadow: 0 4px 15px rgba(107, 90, 206, 0.3);
 }
 
-
 /* 메뉴 콘텐츠 */
 .kiosk-menu-content {
   padding: 20px;
@@ -115,7 +114,7 @@
   text-align: center;
   cursor: pointer;
   transition: all 0.3s ease;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
 .kiosk-menu-item:hover {
@@ -168,7 +167,7 @@
   background: #fff;
   padding: 20px;
   border-radius: 15px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.05);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
   border: 1px solid #f3f1ff;
   margin-bottom: 20px;
 }
@@ -302,11 +301,12 @@
   justify-content: space-between;
   align-items: center;
   border-radius: 15px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   margin-bottom: 20px;
 }
 
-.kiosk-cancel-btn, .kiosk-checkout-btn {
+.kiosk-cancel-btn,
+.kiosk-checkout-btn {
   padding: 12px 30px;
   border: none;
   border-radius: 8px;
@@ -337,6 +337,12 @@
   transform: translateY(-2px);
 }
 
+.kiosk-checkout-btn:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
 /* 안내 문구 */
 .kiosk-instruction {
   text-align: center;
@@ -352,15 +358,15 @@
     grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 12px;
   }
-  
+
   .kiosk-menu-content {
     padding: 15px;
   }
-  
+
   .kiosk-order-summary {
     padding: 15px;
   }
-  
+
   .kiosk-action-bar {
     padding: 12px 15px;
   }
@@ -371,7 +377,7 @@
     margin: 20px auto 0 auto;
     padding: 20px 15px;
   }
-  
+
   .kiosk-header {
     padding: 8px 15px;
     margin: -20px -15px 15px -15px;
@@ -382,90 +388,90 @@
   .restaurant-name h1 {
     font-size: 1.2rem;
   }
-  
+
   .kiosk-back-btn {
     padding: 6px 12px;
     font-size: 0.9rem;
   }
-  
+
   .kiosk-category-tabs {
     padding: 10px 15px;
     flex-wrap: wrap;
     gap: 6px;
     justify-content: center;
   }
-  
+
   .kiosk-category-tab {
     padding: 8px 12px;
     font-size: 0.9rem;
     border-radius: 15px;
   }
-  
 
   .kiosk-menu-content {
     padding: 15px;
   }
-  
+
   .kiosk-menu-grid {
     grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
     gap: 10px;
   }
-  
+
   .kiosk-menu-item {
     padding: 12px;
   }
-  
+
   .kiosk-menu-image {
     height: 80px;
     margin-bottom: 8px;
   }
-  
+
   .kiosk-menu-name {
     font-size: 0.9rem;
     margin-bottom: 6px;
   }
-  
+
   .kiosk-menu-price {
     font-size: 1rem;
   }
-  
+
   .kiosk-order-summary {
     padding: 15px;
   }
-  
+
   .order-summary-header {
     flex-direction: column;
     gap: 6px;
     text-align: center;
     margin-bottom: 12px;
   }
-  
+
   .summary-title {
     font-size: 1.1rem;
   }
-  
+
   .summary-stats {
     gap: 12px;
     font-size: 0.9rem;
   }
-  
+
   .summary-list {
     min-height: 60px;
     max-height: 120px;
   }
-  
+
   .kiosk-action-bar {
     padding: 12px;
     flex-direction: column;
     gap: 8px;
   }
-  
-  .kiosk-cancel-btn, .kiosk-checkout-btn {
+
+  .kiosk-cancel-btn,
+  .kiosk-checkout-btn {
     width: 100%;
     padding: 10px;
     font-size: 0.9rem;
   }
-  
+
   .kiosk-instruction {
     padding: 8px 15px 15px;
     font-size: 0.7rem;
@@ -477,7 +483,7 @@
     margin: 15px auto 0 auto;
     padding: 15px 10px;
   }
-  
+
   .kiosk-header {
     padding: 6px 10px;
     margin: -15px -10px 10px -10px;
@@ -488,12 +494,12 @@
   .restaurant-name h1 {
     font-size: 1rem;
   }
-  
+
   .kiosk-back-btn {
     padding: 5px 10px;
     font-size: 0.8rem;
   }
-  
+
   .kiosk-category-tabs {
     padding: 8px 10px;
     justify-content: flex-start;
@@ -501,60 +507,60 @@
     padding-bottom: 8px;
     gap: 4px;
   }
-  
+
   .kiosk-category-tab {
     white-space: nowrap;
     flex-shrink: 0;
     padding: 6px 10px;
     font-size: 0.8rem;
   }
-  
 
   .kiosk-menu-content {
     padding: 10px;
   }
-  
+
   .kiosk-menu-grid {
     grid-template-columns: repeat(2, 1fr);
     gap: 8px;
   }
-  
+
   .kiosk-menu-item {
     padding: 8px;
   }
-  
+
   .kiosk-menu-image {
     height: 60px;
     margin-bottom: 6px;
   }
-  
+
   .kiosk-menu-name {
     font-size: 0.8rem;
     margin-bottom: 4px;
   }
-  
+
   .kiosk-menu-price {
     font-size: 0.9rem;
   }
-  
+
   .kiosk-order-summary {
     padding: 10px;
   }
-  
+
   .summary-title {
     font-size: 1rem;
   }
-  
+
   .summary-stats {
     font-size: 0.8rem;
     gap: 8px;
   }
-  
+
   .kiosk-action-bar {
     padding: 8px;
   }
-  
-  .kiosk-cancel-btn, .kiosk-checkout-btn {
+
+  .kiosk-cancel-btn,
+  .kiosk-checkout-btn {
     padding: 8px;
     font-size: 0.8rem;
   }


### PR DESCRIPTION
## 변경 사항
- 장바구니가 비어있을 때 결제 버튼이 비활성화
- 비활성화 되었을 때 버튼의 배경색 회색으로 변경

## 테스트 방법
- 메뉴 선택 페이지에서 아무것도 선택하지 않고 결제버튼 클릭

## 스크린샷 (UI 관련시)
<img width="739" height="617" alt="empty" src="https://github.com/user-attachments/assets/f4f567c2-5827-46a9-a52a-1d2c726fd428" />
<img width="758" height="644" alt="full" src="https://github.com/user-attachments/assets/9248f023-4d38-496e-bfaa-768829445ecc" />


## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트