### PR TITLE
[fix/#16] 장바구니 상태 저장 기능 추가

### DIFF
--- a/meal-ticket-system-main/src/pages/KioskMenuPage.jsx
+++ b/meal-ticket-system-main/src/pages/KioskMenuPage.jsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import React, { useState, useEffect } from 'react';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Navbar from '../components/Navbar';
 import RestaurantHeader from '../components/RestaurantHeader';
 import CategoryTabs from '../components/CategoryTabs';
@@ -11,11 +11,19 @@ import '../styles/kioskMenuPage.css';
 
 function KioskMenuPage() {
   const navigate = useNavigate();
+  const location = useLocation();
   const [activeCategory, setActiveCategory] = useState(0);
   const [order, setOrder] = useState([]); // 주문 목록
   const [selectedMenu, setSelectedMenu] = useState(null); // 선택된 메뉴
   const [isModalOpen, setIsModalOpen] = useState(false); // 모달 상태
   
+  // PaymentPage에서 돌아올 때 주문 정보 복원
+  useEffect(() => {
+    if (location.state && location.state.order) {
+      setOrder(location.state.order);
+    }
+  }, [location.state]);
+
   // 정적 데이터
   const store = {
     id: 'student-hall',

--- a/meal-ticket-system-main/src/pages/PaymentPage.jsx
+++ b/meal-ticket-system-main/src/pages/PaymentPage.jsx
@@ -23,7 +23,7 @@ function PaymentPage() {
     1;
 
   const handleBack = () => {
-    navigate('/kiosk');
+    navigate('/kiosk', { state: { order, store } });
   };
 
   const handlePurchase = () => {


### PR DESCRIPTION
## 변경 사항
 결제 화면에서 이전 버튼을 통해 키오스크로 돌아올 경우 장바구니 상태가 보내지지 않았던 문제 해결

## 테스트 방법
- 결제 페이지에서 이전으로 버튼 클릭

## 스크린샷 (UI 관련시)
<img width="1829" height="1016" alt="image" src="https://github.com/user-attachments/assets/34c4a8e4-2b0c-4b8d-80ea-b3fce76a38c4" />
<img width="1941" height="482" alt="image" src="https://github.com/user-attachments/assets/d08171e7-f5f6-411d-aed7-161c1af3b501" />

## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트