### PR TITLE
[fix/#35] 결제 페이지 메뉴 요약 오류

### DIFF
--- a/meal-ticket-system-main/src/pages/KioskMenuPage.jsx
+++ b/meal-ticket-system-main/src/pages/KioskMenuPage.jsx
@@ -265,12 +265,15 @@ function KioskMenuPage() {
         return prevOrder;
       }
       
+      const currentCategoryEnum = categories[activeCategory];
+      const categoryName = categoryDisplayNames[currentCategoryEnum] || currentCategoryEnum || '일반';
+      
       if (existingItem) {
         return prevOrder.map(item =>
           item.id === menu.id ? { ...item, quantity: item.quantity + 1 } : item
         );
       }
-      return [...prevOrder, { ...menu, quantity: 1 }];
+      return [...prevOrder, { ...menu, quantity: 1, category: categoryName }];
     });
   };
 
@@ -310,9 +313,7 @@ function KioskMenuPage() {
 
       if (response.ok) {
         const summary = await response.json();
-        const currentCategoryEnum = categories[activeCategory];
-        const categoryName = categoryDisplayNames[currentCategoryEnum] || currentCategoryEnum || '일반';
-        navigate('/payment', { state: { order, store, categoryName, summary } });
+        navigate('/payment', { state: { order, store, summary } });
       } else {
         alert('재고가 부족하거나 오류가 발생했습니다.');
       }

--- a/meal-ticket-system-main/src/pages/PaymentPage.jsx
+++ b/meal-ticket-system-main/src/pages/PaymentPage.jsx
@@ -10,7 +10,7 @@ function PaymentPage() {
   const [isLoading, setIsLoading] = useState(false);
   
   //정보
-  const { order, store, menu, categoryName } = location.state || {};
+  const { order, store, menu } = location.state || {};
   
   //총액
   const totalAmount = order ? 
@@ -121,6 +121,10 @@ function PaymentPage() {
                         <span className="info-value">{item.name}</span>
                       </div>
                       <div className="info-row">
+                        <span className="info-label">카테고리</span>
+                        <span className="info-value">{item.category || '일반'}코너</span>
+                      </div>
+                      <div className="info-row">
                         <span className="info-label">수량</span>
                         <span className="info-value">{item.quantity}개</span>
                       </div>
@@ -133,7 +137,7 @@ function PaymentPage() {
                   ))}
                   <div className="info-row">
                     <span className="info-label">수령 위치</span>
-                    <span className="info-value">{store.name} {categoryName}코너</span>
+                    <span className="info-value">{store.name}</span>
                   </div>
                 </>
               ) : (
@@ -143,12 +147,16 @@ function PaymentPage() {
                     <span className="info-value">{menu.name}</span>
                   </div>
                   <div className="info-row">
+                    <span className="info-label">카테고리</span>
+                    <span className="info-value">{menu.category || '일반'}코너</span>
+                  </div>
+                  <div className="info-row">
                     <span className="info-label">금액</span>
                     <span className="info-value">{menu.price.toLocaleString()}원</span>
                   </div>
                   <div className="info-row">
                     <span className="info-label">수령 위치</span>
-                    <span className="info-value">{store.name} {categoryName}코너</span>
+                    <span className="info-value">{store.name}</span>
                   </div>
                 </>
               )}


### PR DESCRIPTION
## 변경 사항
- 각각 다른 카테고리의 음식을 선택했을 때 하나의 카테고리만 보이던 것을 여러 개의 카테고리가 보이도록 수정함.
- 수령 위치에는 선택한 매장의 이름만을 출력함.

## 테스트 방법
- 아무 식당이나 클릭, 다른 카테고리의 음식을 장바구니에 담은 후 결제 페이지로 이동했을 때 확인 가능함.

## 스크린샷 (UI 관련시)
- Before
<img width="1327" height="1252" alt="image" src="https://github.com/user-attachments/assets/1e39b0de-0719-4c43-9b2d-633b6ad6999f" />

- After
<img width="386" height="593" alt="image" src="https://github.com/user-attachments/assets/5dd4825d-508e-4160-88fa-c0d70b9043a9" />


## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트