### PR TITLE
[feat] 결제 페이지 대기 시간 하드코딩 데이터 제거, 우측 디테일 추가

### DIFF
--- a/meal-ticket-system-main/src/pages/PaymentPage.jsx
+++ b/meal-ticket-system-main/src/pages/PaymentPage.jsx
@@ -21,6 +21,11 @@ function PaymentPage() {
     order.reduce((sum, item) => sum + item.quantity, 0) : 
     1;
 
+  // 최대 대기 시간 계산
+  const maxWaitTime = order && order.length > 0 ? 
+    Math.max(...order.map(item => item.expectedWaitTime || 0).filter(time => time > 0)) : 
+    0;
+
 
   const userName = localStorage.getItem('userName') || '사용자';
   const accessToken = localStorage.getItem('accessToken');
@@ -174,7 +179,11 @@ function PaymentPage() {
             </div>
 
             <div className="payment-notice">
-              실제 음식이 나오기까지는 시간이 00분 소요될 수 있습니다.
+              {maxWaitTime > 0 ? (
+                `실제 음식이 나오기까지는 시간이 약 ${maxWaitTime}분 소요될 수 있습니다.`
+              ) : (
+                '실제 음식이 나오기까지는 시간이 소요될 수 있습니다.'
+              )}
             </div>
           </div>  
 
@@ -183,8 +192,14 @@ function PaymentPage() {
               <h2 className="section-title">결제 금액</h2>
               <div className="section-divider"></div>
               <div className="summary-content">
-                <div className="summary-item">구매 금액</div>
-                <div className="summary-item">관련 정보</div>
+                <div className="summary-item">
+                  <span>상품 금액</span>
+                  <span>{totalAmount.toLocaleString()}원</span>
+                </div>
+                <div className="summary-item">
+                  <span>예상 대기</span>
+                  <span>{maxWaitTime > 0 ? `약 ${maxWaitTime}분` : '정보 없음'}</span>
+                </div>
               </div>
               <div className="summary-total">
                 <span className="total-count">총 {totalItems}건</span>


### PR DESCRIPTION
## 변경 사항
- 결제 페이지 우측에 세부 정보가 뜨지 않음.
- 결제 페이지 좌측 최하단 대기시간 정보가 하드코딩됨. -> null값일 경우 대기 시간이 소요될 수 있음을 알림. 선택한 메뉴가 여러 개일 경우 그 중 가장 긴 대기 시간만을 보냄.

## 테스트 방법
- 로그인 후 아무 식당을 선택, 결제 페이지로 이동함.

## 스크린샷 (UI 관련시)
<img width="1112" height="702" alt="image" src="https://github.com/user-attachments/assets/4b60a2fc-6b6a-492a-b160-62b19f7680fc" />
<img width="673" height="412" alt="image" src="https://github.com/user-attachments/assets/689f4914-7325-4da0-a9f4-e00a2deccc4e" />


## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트