### PR TITLE
[fix/#38] : 소셜사용자 로그인 실패 및 결제 불가능 문제 해결

### DIFF
--- a/meal-ticket-system-main/src/components/Navbar.jsx
+++ b/meal-ticket-system-main/src/components/Navbar.jsx
@@ -8,60 +8,50 @@ import { API_BASE_URL } from '../api';
 function Navbar() {
   const navigate = useNavigate();
   const location = useLocation();
-  const [userId, setUserId] = useState('');
+  const [userName, setUserName] = useState('');
   const [userRole, setUserRole] = useState('');
 
   useEffect(() => {
     // 컴포넌트 마운트 및 경로 변경 시 사용자 정보 업데이트
-    const storedUserId = localStorage.getItem('userId');
+    const storedUserName = localStorage.getItem('userName');
     const storedUserRole = localStorage.getItem('userRole');
-    setUserId(storedUserId || '');
+    setUserName(storedUserName || '');
     setUserRole(storedUserRole || '');
   }, [location.pathname]);
 
   const clearLocalStorage = () => {
     localStorage.removeItem('accessToken');
-    localStorage.removeItem('userId');
+    localStorage.removeItem('userName');
     localStorage.removeItem('userName');
     localStorage.removeItem('userRole');
-    setUserId('');
+    setUserName('');
     setUserRole('');
     navigate('/');
   };
 
   const handleLogout = async () => {
+
     const token = localStorage.getItem('accessToken');
     
-    // 토큰이 없으면 바로 정리하고 이동
-    if (!token) {
-      clearLocalStorage();
-      return;
-    }
-
     try {
-      const response = await fetch(`${API_BASE_URL}/api/auth/logout`, {
-        method: 'POST',
-        headers: {
-          'Authorization': token,
-          'Content-Type': 'application/json',
-        }
-      });
-
-      const data = await response.json();
-      // 로그아웃 성공
-      if (response.ok) {
-        // 정리
-        clearLocalStorage();
-      } else {
-        // 토큰이 유효하지 않아도 정리
-        console.error('로그아웃 오류:', data);
-        clearLocalStorage();
+      const headers = {
+        'Content-Type': 'application/json',
+      };
+      
+      if (token) {
+        headers['Authorization'] = `Bearer ${token}`;
       }
+
+      await fetch(`${API_BASE_URL}/api/auth/logout`, {
+        method: 'POST',
+        headers: headers,
+        credentials: 'include'
+      });
     } catch (err) {
-      // 네트워크 오류에도 정리
-      console.error('로그아웃 네트워크 오류:', err);
-      clearLocalStorage();
+      
     }
+    
+    clearLocalStorage();
   };
 
   // 현재 경로가 해당 링크와 일치하는지 확인하는 함수
@@ -110,13 +100,13 @@ function Navbar() {
         {renderMenuByRole()}
       </ul>
       <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
-        {userId && (
+        {userName && (
           <span style={{ 
             fontSize: '14px', 
             color: '#666',
             fontWeight: '500'
           }}>
-            {userId}
+            {userName}
           </span>
         )}
         <button className="navbar__logout" onClick={handleLogout}>로그아웃</button>

--- a/meal-ticket-system-main/src/pages/PaymentPage.jsx
+++ b/meal-ticket-system-main/src/pages/PaymentPage.jsx
@@ -57,12 +57,18 @@ function PaymentPage() {
         paymentMethod: 'NAVER_PAY'
       };
 
+      const headers = {
+        'Content-Type': 'application/json'
+      };
+      
+      if (accessToken) {
+        headers['Authorization'] = `Bearer ${accessToken}`;
+      }
+
       const response = await fetch(`${API_BASE_URL}/api/orders/checkout`, {
         method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': accessToken
-        },
+        headers: headers,
+        credentials: 'include',
         body: JSON.stringify(orderData)
       });
 

--- a/meal-ticket-system-main/src/pages/SocialSignUpPhone.jsx
+++ b/meal-ticket-system-main/src/pages/SocialSignUpPhone.jsx
@@ -55,6 +55,9 @@ function SocialSignUpPhone() {
         if (userName) {
           localStorage.setItem('userName', userName);
         }
+        if (data.token) {
+          localStorage.setItem('accessToken', data.token);
+        }
         navigate('/ticket-purchase');
       } else {
         setError(data.error || data.message || '설정에 실패했습니다.');

--- a/meal-ticket-system-main/src/pages/TicketPurchase.jsx
+++ b/meal-ticket-system-main/src/pages/TicketPurchase.jsx
@@ -27,6 +27,18 @@ function TicketPurchase() {
   };
 
   useEffect(() => {
+    // 소셜 로그인 사용자는 자동으로 STUDENT role 설정
+    const userRole = localStorage.getItem('userRole');
+    
+    if (!userRole) {
+      // role이 없으면 소셜 로그인 사용자로 간주하여 STUDENT로 설정
+      localStorage.setItem('userRole', 'STUDENT');
+      localStorage.setItem('userName', '소셜 이용자');
+      // Navbar 업데이트를 위해 페이지 새로고침
+      window.location.reload();
+      return;
+    }
+    
     fetchRestaurants();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);


### PR DESCRIPTION
## 변경 사항
1. 소셜 사용자 로그인 시 initial-setup을 호출하지 못해 role, name 값을 못 받음.
-> 소셜 로그인 role = STUDENT 고정, name = 소셜이용자 고정

2. 소셜 사용자 로그인 시 token을 저장하지 못해 구매 불가
-> 소셜 사용자 토큰 저장 기능 추가

3. 결제 방식이 localStorage 기반이라 쿠키를 기반으로 하는 소셜 로그인은 결제가 안됨.
-> 쿠키 기반 구매 로직 추가

4. 네비게이션 바에 출력되던 UserID를 UserName이 출력되도록 변경
(소셜 이용자는 id가 DB에 저장된 인덱스 숫자로 저장되기 때문)

5. 로그아웃 토큰 형식 추가

## 테스트 방법
- 소셜 로그인 후 티켓 구매

## 스크린샷 (UI 관련시)
<img width="1995" height="961" alt="image" src="https://github.com/user-attachments/assets/6d3b4793-3025-4669-9f97-92e9fb830cce" />

## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트