### PR TITLE
[feat/#54] 최소 메뉴 수량 및 가격 설정, 완료 버튼 삭제

### DIFF
--- a/meal-ticket-system-main/src/components/MenuModal.jsx
+++ b/meal-ticket-system-main/src/components/MenuModal.jsx
@@ -173,6 +173,7 @@ function MenuModal({ isOpen, onClose, onSubmit, initialData = null, categories =
               onChange={handleInputChange}
               placeholder="가격을 입력하세요."
               className="menu-modal-form-input"
+              min="1"
               required
             />
           </div>
@@ -186,6 +187,7 @@ function MenuModal({ isOpen, onClose, onSubmit, initialData = null, categories =
               onChange={handleInputChange}
               placeholder="식권 매수를 입력하세요."
               className="menu-modal-form-input"
+              min="1"
               required
             />
           </div>

--- a/meal-ticket-system-main/src/pages/AdminMenuManage.jsx
+++ b/meal-ticket-system-main/src/pages/AdminMenuManage.jsx
@@ -351,9 +351,6 @@ function AdminMenuManage() {
           <button className="admin-menu-back-btn" onClick={handleBack}>
             이전으로
           </button>
-          <button className="admin-menu-confirm-btn" onClick={() => alert('변경사항이 저장되었습니다!')}>
-            완료
-          </button>
         </div>
       </div>
 


### PR DESCRIPTION
## 변경 사항
- 관리자 메뉴 등록, 수정에서 메뉴의 가격과 수량 최소치(1) 설정
- 매장 관리 내 완료 버튼 제거

## 테스트 방법
- 관리자 접속 후 매장 관리

## 스크린샷 (UI 관련시)
<img width="1003" height="1381" alt="image" src="https://github.com/user-attachments/assets/161c8828-284f-4367-a902-30696ffb1d99" />
<img width="2237" height="1510" alt="image" src="https://github.com/user-attachments/assets/02b6119b-917d-40e3-aa8c-5545b6ca797a" />

## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트