### PR TITLE
Hotfix/graph data change

### DIFF
--- a/meal-ticket-system-main/src/components/MenuChartSection.jsx
+++ b/meal-ticket-system-main/src/components/MenuChartSection.jsx
@@ -43,11 +43,7 @@ function MenuChartSection({ salesGraphData, expectedWaitTime }) {
   let minDiff = Infinity;
   
   for (let i = salesGraphData.length - 1; i >= 0; i--) {
-    const dataTime = new Date(
-      salesGraphData[i].time.includes('Z') 
-        ? salesGraphData[i].time 
-        : salesGraphData[i].time + 'Z'
-    );
+    const dataTime = new Date(salesGraphData[i].time);
     const diff = Math.abs(targetTime - dataTime);
     if (diff < minDiff) {
       minDiff = diff;
@@ -57,12 +53,12 @@ function MenuChartSection({ salesGraphData, expectedWaitTime }) {
   
   // 15분 구간별 판매량 집계 (5분 데이터 3개 합산)
   const recentData = [];
-  for (let i = closestIndex; i >= 0 && recentData.length < 8; i -= 3) {
+  for (let i = closestIndex; i >= 2 && recentData.length < 8; i -= 3) {
     let intervalSum = 0;
-    // 3개 구간 합산 (5분 × 3 = 15분)
-    for (let j = 0; j < 3 && (i - j) >= 0; j++) {
-      intervalSum += salesGraphData[i - j].salesInInterval;
-    }
+    intervalSum = salesGraphData[i].salesInInterval + 
+                  salesGraphData[i - 1].salesInInterval + 
+                  salesGraphData[i - 2].salesInInterval;
+    
     recentData.unshift({
       time: salesGraphData[i].time,
       salesInInterval: intervalSum
@@ -72,9 +68,7 @@ function MenuChartSection({ salesGraphData, expectedWaitTime }) {
 
   const chartData = {
     labels: filteredData.map(point => {
-      //UTC 시간을 KST로 변환하여 HH:MM 형식으로 표시, 명시적 Z 추가
-      const utcTime = point.time.includes('Z') ? point.time : point.time + 'Z';
-      const date = new Date(utcTime);
+      const date = new Date(point.time);
       const hours = String(date.getHours()).padStart(2, '0');
       const minutes = String(date.getMinutes()).padStart(2, '0');
       return `${hours}:${minutes}`;

--- a/meal-ticket-system-main/src/components/MenuChartSection.jsx
+++ b/meal-ticket-system-main/src/components/MenuChartSection.jsx
@@ -55,9 +55,18 @@ function MenuChartSection({ salesGraphData, expectedWaitTime }) {
     }
   }
   
+  // 15분 구간별 판매량 집계 (5분 데이터 3개 합산)
   const recentData = [];
-  for (let i = closestIndex; i >= 0 && recentData.length < 8; i -= 15) {
-    recentData.unshift(salesGraphData[i]);
+  for (let i = closestIndex; i >= 0 && recentData.length < 8; i -= 3) {
+    let intervalSum = 0;
+    // 3개 구간 합산 (5분 × 3 = 15분)
+    for (let j = 0; j < 3 && (i - j) >= 0; j++) {
+      intervalSum += salesGraphData[i - j].salesInInterval;
+    }
+    recentData.unshift({
+      time: salesGraphData[i].time,
+      salesInInterval: intervalSum
+    });
   }
   const filteredData = recentData;
 
@@ -72,8 +81,8 @@ function MenuChartSection({ salesGraphData, expectedWaitTime }) {
     }),
     datasets: [
       {
-        label: '누적 판매',
-        data: filteredData.map(point => point.cumulativeAtPoint),
+        label: '15분 구간 판매',
+        data: filteredData.map(point => point.salesInInterval),
         backgroundColor: '#6b5ace',
         borderColor: '#5a4ab8',
         borderWidth: 1,


### PR DESCRIPTION
## 변경 사항
- 판매 그래프
- 현재 시각 기준으로 과거의 8개 데이터 15분 간격으로 제시
- 제시되는 데이터는 15분동안의 해당 메뉴 판매량임
- 특정 시간대에서 그래프 데이터가 2개만 보이던 것을 수정

## 테스트 방법
- 해당 브랜치로 이동 후 메뉴 구매, 확인

## 스크린샷 (UI 관련시)
- 이미지 찍기가 애매해서 첨부 안합니다...

## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트