### PR TITLE
[fix/#54] 회원가입 페이지 로고 숨기기

### DIFF
--- a/meal-ticket-system-main/src/styles/signUp.css
+++ b/meal-ticket-system-main/src/styles/signUp.css
@@ -252,10 +252,7 @@
   }
   
   .signup2-left {
-    width: 100%;
-    max-width: none;
-    height: 200px;
-    order: 2;
+    display: none; /* 모바일에서 로고 영역 숨김 */
   }
   
   .signup2-logo-text {


### PR DESCRIPTION
## 변경 사항
- 회원가입 페이지에서 화면이 줄어들 경우(모바일) 로고가 입력칸을 가려버림 -> 화면이 줄어들면 로고 숨기기

## 테스트 방법
- 회원가입 페이지 접속

## 스크린샷 (UI 관련시)
<img width="897" height="1374" alt="image" src="https://github.com/user-attachments/assets/234917ed-6699-4d65-8f59-0e95e1c7ada1" />
<img width="838" height="1445" alt="image" src="https://github.com/user-attachments/assets/ecb78cc3-5fbc-484a-beb6-a9da7af32964" />


## 체크리스트
- [ ] 코드 리뷰 완료
- [ ] 테스트 확인
- [ ] 문서 업데이트